### PR TITLE
Allow a configurable clickSuppression distance

### DIFF
--- a/lib/src/draggable.dart
+++ b/lib/src/draggable.dart
@@ -55,6 +55,9 @@ class Draggable {
   /// See [Draggable] constructor.
   String draggingClassBody;
 
+  /// The minimum distance for a drag to prevent click events.
+  int clickSuppression = 0;
+
   // -------------------
   // Events
   // -------------------
@@ -260,8 +263,11 @@ class Draggable {
         event.preventDefault();
       }
 
-      if (event is MouseEvent) {
-        // Prevent MouseEvent from firing a click after mouseUp event.
+      if (event is MouseEvent &&
+          (clickSuppression <= 0 ||
+              _currentDrag.startPosition.distanceTo(_currentDrag.position) >
+                  clickSuppression)) {
+        // Prevent MouseEvent from firing a click after mouseUp event if the move was significant.
         _suppressClickEvent();
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dnd
-version: 0.3.2
+version: 0.3.3
 author: Marco Jakob <majakob@gmx.ch>
 description: Drag and Drop for Dart web apps with mouse and touch support.
 homepage: http://code.makery.ch/library/dart-drag-and-drop/


### PR DESCRIPTION
We found that the click suppression was a little too aggressive for users with less mousing accuracy. They would attempt to click and trigger a small drag. Which then suppressed the click event and prevented the action they intended to complete.

I chose not to attempt to remove the code as it was very clearly intentionally added. Instead I provided a means for consumers to customize the interaction to their needs. 

By adding a configurable suppression minimum distance it allows the consumer of dnd to choose when to suppress clicks.

I'm open to alternatives.

@marcojakob 