### PR TITLE
Fix strong-mode type errors

### DIFF
--- a/lib/src/draggable.dart
+++ b/lib/src/draggable.dart
@@ -333,8 +333,7 @@ class Draggable {
       var activeElement = document.activeElement;
       if (activeElement is TextAreaElement) {
         activeElement.setSelectionRange(0, 0);
-      }
-      if (activeElement is InputElement) {
+      } else if (activeElement is InputElement) {
         activeElement.setSelectionRange(0, 0);
       }
     } catch (_) {

--- a/lib/src/draggable.dart
+++ b/lib/src/draggable.dart
@@ -331,7 +331,10 @@ class Draggable {
     // Try to remove selection from textarea or input.
     try {
       var activeElement = document.activeElement;
-      if (activeElement is TextAreaElement || activeElement is InputElement) {
+      if (activeElement is TextAreaElement) {
+        activeElement.setSelectionRange(0, 0);
+      }
+      if (activeElement is InputElement) {
         activeElement.setSelectionRange(0, 0);
       }
     } catch (_) {

--- a/lib/src/draggable_avatar.dart
+++ b/lib/src/draggable_avatar.dart
@@ -114,7 +114,7 @@ abstract class AvatarHandler {
   /// Sets the CSS transform translate of [avatar]. Uses requestAnimationFrame
   /// to speed up animation.
   void setTranslate(Point position) {
-    Function updateFunction = () {
+    void updateFunction() {
       // Unsing `translate3d` to activate GPU hardware-acceleration (a bit of a hack).
       if (avatar != null) {
         avatar.style.transform = 'translate3d(${position.x}px, ${position.y}px, 0)';

--- a/lib/src/draggable_manager.dart
+++ b/lib/src/draggable_manager.dart
@@ -373,7 +373,7 @@ class _PointerManager extends _EventManager {
 
     // Function to be called on all elements of [_elementOrElementList].
     var installFunc = (Element element) {
-      startSubs.add(element.on[downEventName].listen((event) {
+      startSubs.add(element.on[downEventName].listen((MouseEvent event) {
         // Ignore if drag is already beeing handled.
         if (_currentDrag != null) {
           return;
@@ -430,7 +430,7 @@ class _PointerManager extends _EventManager {
   void installMove() {
     String moveEventName = msPrefix ? 'MSPointerMove' : 'pointermove';
 
-    dragSubs.add(document.on[moveEventName].listen((event) {
+    dragSubs.add(document.on[moveEventName].listen((MouseEvent event) {
       handleMove(event, event.page, event.client);
     }));
   }
@@ -439,7 +439,7 @@ class _PointerManager extends _EventManager {
   void installEnd() {
     String endEventName = msPrefix ? 'MSPointerUp' : 'pointerup';
 
-    dragSubs.add(document.on[endEventName].listen((event) {
+    dragSubs.add(document.on[endEventName].listen((MouseEvent event) {
       handleEnd(event, event.target, event.page, event.client);
     }));
   }


### PR DESCRIPTION
This CL fixes [strong mode](https://github.com/dart-lang/sdk/blob/master/pkg/dev_compiler/STRONG_MODE.md) type errors, which makes it possible to use `dnd` package with [DDC](https://github.com/dart-lang/sdk/tree/master/pkg/dev_compiler) compiler.