### PR TITLE
Handle the edge case where destroy is called while dragging an avatar.

### DIFF
--- a/lib/src/draggable.dart
+++ b/lib/src/draggable.dart
@@ -308,6 +308,7 @@ class Draggable {
     // Destroy all managers.
     _eventManagers.forEach((m) => m.destroy());
     _eventManagers.clear();
+    avatarHandler?.avatar?.remove();
   }
 
   /// Cancels drag subscriptions and resets to initial state.


### PR DESCRIPTION
This addresses https://github.com/marcojakob/dart-dnd/issues/17

I tested it in our use case, and it worked.  I didn't add unit tests, because it doesn't look like the repo has any setup for it, and I don't want to force my unit test tool opinions upon you.