### PR TITLE
Provide reasonable fallback for event target when mouse position exits viewport

### DIFF
--- a/lib/src/draggable_manager.dart
+++ b/lib/src/draggable_manager.dart
@@ -121,6 +121,13 @@ abstract class _EventManager {
     startSubs.clear();
   }
 
+  /// Determine a target using `document.elementFromPoint` via the provided [clientPosition].
+  ///
+  /// Falls back to `document.body` if no element is found at the provided [clientPosition].
+  EventTarget _getRealTargetFromPoint(Point clientPosition) {
+    return document.elementFromPoint(clientPosition.x, clientPosition.y) ?? document.body;
+  }
+
   /// Determine the actual target that should receive the event because
   /// mouse or touch event might have occurred on a drag avatar.
   ///
@@ -130,7 +137,7 @@ abstract class _EventManager {
   EventTarget _getRealTarget(Point clientPosition, {EventTarget target}) {
     // If no target was provided get it.
     if (target == null) {
-      target = document.elementFromPoint(clientPosition.x, clientPosition.y);
+      target = _getRealTargetFromPoint(clientPosition);
     }
 
     // Test if target is the drag avatar.
@@ -139,7 +146,7 @@ abstract class _EventManager {
 
       // Target is the drag avatar, get element underneath.
       drg.avatarHandler.avatar.style.visibility = 'hidden';
-      target = document.elementFromPoint(clientPosition.x, clientPosition.y);
+      target = _getRealTargetFromPoint(clientPosition);
       drg.avatarHandler.avatar.style.visibility = 'visible';
     }
 


### PR DESCRIPTION
Currently, when the "container" that holds the draggables sits flush against the edge of the viewport, and the user moves their mouse cursor outside the bounds of the visible viewport while dragging, an unhandled exception is thrown (see screen capture below).

![dart-dnd-scrolling-list-exception](https://cloud.githubusercontent.com/assets/1750797/26802626/0c2c0a30-49f6-11e7-8fed-69398a1f2459.gif)

These changes make it so that a valid `EventTarget` is provided at all times within `_getRealTarget`.

For your approval @marcojakob 

---

cc/ @greglittlefield-wf @clairesarsam-wf @jacehensley-wf @joelleibow-wf