### PR TITLE
Fix strong mode errors

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,2 +1,7 @@
 analyzer:
   strong-mode: true
+linter:
+  rules:
+    - annotate_overrides
+    - cancel_subscriptions
+    - close_sinks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## Version 0.4.0 (2017-06-27)
+
+* Fix strong mode errors (#20).
+
+
 ## Version 0.3.6 (2017-06-06)
 
 * Fix bug: Provide reasonable fallback for event target when mouse position exits viewport (#19).

--- a/lib/dnd.dart
+++ b/lib/dnd.dart
@@ -11,4 +11,3 @@ part 'src/draggable_dispatch.dart';
 part 'src/draggable_manager.dart';
 part 'src/dropzone.dart';
 part 'src/dropzone_acceptor.dart';
-

--- a/lib/src/draggable.dart
+++ b/lib/src/draggable.dart
@@ -6,7 +6,6 @@ part of dnd;
 /// the [CustomEvent]s.
 _DragInfo _currentDrag;
 
-
 /// The [Draggable] detects drag operations for touch and mouse interactions and
 /// optionally creates a drag avatar for visual feedback of the drag. Event
 /// streams are provided to track touch or mouse dragging:
@@ -17,7 +16,6 @@ _DragInfo _currentDrag;
 ///
 /// A [Draggable] can be created for one [Element] or an [ElementList].
 class Draggable {
-
   /// Counter to generate a unique id for each instance.
   static int idCounter = 0;
 
@@ -72,8 +70,8 @@ class Draggable {
   /// will also be fired.
   Stream<DraggableEvent> get onDragStart {
     if (_onDragStart == null) {
-      _onDragStart = new StreamController<DraggableEvent>.broadcast(sync: true,
-          onCancel: () => _onDragStart = null);
+      _onDragStart = new StreamController<DraggableEvent>.broadcast(
+          sync: true, onCancel: () => _onDragStart = null);
     }
     return _onDragStart.stream;
   }
@@ -81,8 +79,8 @@ class Draggable {
   /// Fired periodically throughout the drag operation.
   Stream<DraggableEvent> get onDrag {
     if (_onDrag == null) {
-      _onDrag = new StreamController<DraggableEvent>.broadcast(sync: true,
-          onCancel: () => _onDrag = null);
+      _onDrag = new StreamController<DraggableEvent>.broadcast(
+          sync: true, onCancel: () => _onDrag = null);
     }
     return _onDrag.stream;
   }
@@ -91,8 +89,8 @@ class Draggable {
   /// Is also fired when the user clicks the 'esc'-key or the window loses focus.
   Stream<DraggableEvent> get onDragEnd {
     if (_onDragEnd == null) {
-      _onDragEnd = new StreamController<DraggableEvent>.broadcast(sync: true,
-          onCancel: () => _onDragEnd = null);
+      _onDragEnd = new StreamController<DraggableEvent>.broadcast(
+          sync: true, onCancel: () => _onDragEnd = null);
     }
     return _onDragEnd.stream;
   }
@@ -150,16 +148,14 @@ class Draggable {
   /// The [draggingClassBody] is the css class set to the html body tag
   /// during a drag. If set to null, no such css class is added.
   Draggable(elementOrElementList,
-      { this.avatarHandler: null,
-        this.horizontalOnly: false,
-        this.verticalOnly: false,
-        this.handle: null,
-        this.cancel: 'input, textarea, button, select, option',
-        this.draggingClass: 'dnd-dragging',
-        this.draggingClassBody: 'dnd-drag-occurring'})
-
+      {this.avatarHandler: null,
+      this.horizontalOnly: false,
+      this.verticalOnly: false,
+      this.handle: null,
+      this.cancel: 'input, textarea, button, select, option',
+      this.draggingClass: 'dnd-dragging',
+      this.draggingClassBody: 'dnd-drag-occurring'})
       : this._elementOrElementList = elementOrElementList {
-
     // Detect IE Pointer Event Support.
     JsObject jsWindow = new JsObject.fromBrowserObject(window);
     JsObject jsNavigator = jsWindow['navigator'];
@@ -167,11 +163,9 @@ class Draggable {
     if (jsNavigator.hasProperty('pointerEnabled')) {
       // We're on IE11 or higher supporting pointerEvents.
       _eventManagers.add(new _PointerManager(this));
-
-    } else if (jsNavigator.hasProperty('msPointerEnabled')){
+    } else if (jsNavigator.hasProperty('msPointerEnabled')) {
       // We're on IE10 supporting msPointerEvents.
       _eventManagers.add(new _PointerManager(this, msPrefix: true));
-
     } else {
       // We're on other browsers. Install touch and mouse listeners.
       if (TouchEvent.supported) {
@@ -189,7 +183,8 @@ class Draggable {
 
     // Pass event to AvatarHandler.
     if (avatarHandler != null) {
-      avatarHandler._handleDragStart(_currentDrag.element, _currentDrag.position);
+      avatarHandler._handleDragStart(
+          _currentDrag.element, _currentDrag.position);
     }
 
     // Fire the drag start event with start position.
@@ -218,7 +213,8 @@ class Draggable {
   void _handleDrag(UIEvent moveEvent, EventTarget target) {
     // Pass event to AvatarHandler.
     if (avatarHandler != null) {
-      avatarHandler._handleDrag(_currentDrag.startPosition, _currentDrag.position);
+      avatarHandler._handleDrag(
+          _currentDrag.startPosition, _currentDrag.position);
     }
 
     // Dispatch internal drag enter, over, or leave event.
@@ -244,7 +240,8 @@ class Draggable {
     if (_currentDrag.started) {
       // Pass event to AvatarHandler.
       if (avatarHandler != null) {
-        avatarHandler._handleDragEnd(_currentDrag.startPosition, _currentDrag.position);
+        avatarHandler._handleDragEnd(
+            _currentDrag.startPosition, _currentDrag.position);
       }
 
       // Dispatch internal drop event if drag was not cancelled.
@@ -254,8 +251,8 @@ class Draggable {
 
       // Fire dragEnd event.
       if (_onDragEnd != null) {
-        _onDragEnd.add(new DraggableEvent._(event, _currentDrag,
-            cancelled: cancelled));
+        _onDragEnd.add(
+            new DraggableEvent._(event, _currentDrag, cancelled: cancelled));
       }
 
       // Prevent TouchEvent from emulating a click after touchEnd event.
@@ -288,7 +285,8 @@ class Draggable {
   /// [MouseEvent]s. We have to wait for and cancel a potential click event
   /// happening after the mouseUp event.
   void _suppressClickEvent() {
-    StreamSubscription clickPreventer = _elementOrElementList.onClick.listen((event) {
+    StreamSubscription clickPreventer =
+        _elementOrElementList.onClick.listen((event) {
       event.stopPropagation();
       event.preventDefault();
     });
@@ -346,7 +344,6 @@ class Draggable {
   }
 }
 
-
 /// Event used when a drag is detected.
 class DraggableEvent {
   /// The [Element] that is beeing dragged.
@@ -377,7 +374,8 @@ class DraggableEvent {
   final bool cancelled;
 
   /// Private constructor for [DraggableEvent].
-  DraggableEvent._(this.originalEvent, _DragInfo dragInfo, {this.cancelled: false})
+  DraggableEvent._(this.originalEvent, _DragInfo dragInfo,
+      {this.cancelled: false})
       : draggableElement = dragInfo.element,
         avatarHandler = dragInfo.avatarHandler,
         startPosition = dragInfo.startPosition,
@@ -409,9 +407,9 @@ class _DragInfo {
   final bool verticalOnly;
 
   _DragInfo(this.draggableId, this.element, this.startPosition,
-      { this.avatarHandler: null,
-        this.horizontalOnly: false,
-        this.verticalOnly: false}) {
+      {this.avatarHandler: null,
+      this.horizontalOnly: false,
+      this.verticalOnly: false}) {
     // Initially set current position to startPosition.
     _position = startPosition;
   }

--- a/lib/src/draggable_avatar.dart
+++ b/lib/src/draggable_avatar.dart
@@ -4,7 +4,6 @@ part of dnd;
 /// a drag avatar. A drag avatar provides visual feedback during the drag
 /// operation.
 abstract class AvatarHandler {
-
   /// Returns the [avatar] element during a drag operation.
   ///
   /// If there is no drag operation going on, [avatar] will be null.
@@ -117,9 +116,12 @@ abstract class AvatarHandler {
     void updateFunction() {
       // Unsing `translate3d` to activate GPU hardware-acceleration (a bit of a hack).
       if (avatar != null) {
-        avatar.style.transform = 'translate3d(${position.x}px, ${position.y}px, 0)';
+        avatar.style.transform =
+            'translate3d(${position.x}px, ${position.y}px, 0)';
       }
-    };
+    }
+
+    ;
 
     // Use request animation frame to update the transform translate.
     AnimationHelper.requestUpdate(updateFunction);
@@ -149,18 +151,16 @@ abstract class AvatarHandler {
   void cacheMargins() {
     // Calculate margins.
     var computedStyles = avatar.getComputedStyle();
-    _marginLeft = num.parse(computedStyles.marginLeft.replaceFirst('px', ''),
-        (s) => 0);
-    _marginTop = num.parse(computedStyles.marginTop.replaceFirst('px', ''),
-        (s) => 0);
+    _marginLeft =
+        num.parse(computedStyles.marginLeft.replaceFirst('px', ''), (s) => 0);
+    _marginTop =
+        num.parse(computedStyles.marginTop.replaceFirst('px', ''), (s) => 0);
   }
 }
-
 
 /// The [OriginalAvatarHandler] uses the draggable element itself as drag
 /// avatar. It uses absolute positioning of the avatar.
 class OriginalAvatarHandler extends AvatarHandler {
-
   Point _draggableStartOffset;
 
   @override
@@ -191,24 +191,22 @@ class OriginalAvatarHandler extends AvatarHandler {
 
     // Set the new position as left/top. Prevent from moving past the top and
     // left borders as the user might not be able to grab the element any more.
-    Point constrainedPosition = new Point(math.max(1, position.x),
-        math.max(1, position.y));
+    Point constrainedPosition =
+        new Point(math.max(1, position.x), math.max(1, position.y));
 
     setLeftTop(constrainedPosition - startPosition + _draggableStartOffset);
   }
 }
 
-
 /// [CloneAvatarHandler] creates a clone of the draggable element as drag avatar.
 /// The avatar is removed at the end of the drag operation.
 class CloneAvatarHandler extends AvatarHandler {
-
   @override
   void dragStart(Element draggable, Point startPosition) {
     // Clone the draggable to create the avatar.
     avatar = (draggable.clone(true) as Element)
-        ..attributes.remove('id')
-        ..style.cursor = 'inherit';
+      ..attributes.remove('id')
+      ..style.cursor = 'inherit';
 
     // Ensure avatar has an absolute position.
     avatar.style.position = 'absolute';
@@ -233,10 +231,8 @@ class CloneAvatarHandler extends AvatarHandler {
   }
 }
 
-
 /// Simple helper class to speed up animation with requestAnimationFrame.
 class AnimationHelper {
-
   static Function _lastUpdateFunction;
   static bool _updating = false;
 

--- a/lib/src/draggable_dispatch.dart
+++ b/lib/src/draggable_dispatch.dart
@@ -5,7 +5,6 @@ part of dnd;
 /// Those events are only meant for communication between [Draggable]s and
 /// [Dropzone]s and not to be consumed by users of the library.
 class _DragEventDispatcher {
-
   /// Custom drag enter event that is fired on the element that is entered.
   static const String CUSTOM_DRAG_ENTER = '_customDragEnter';
 
@@ -21,21 +20,20 @@ class _DragEventDispatcher {
   /// Stream provider for [CUSTOM_DRAG_ENTER] events. The relatedTarget contains
   /// the [Element] the user entered from (may be null).
   static EventStreamProvider<MouseEvent> enterEvent =
-       new EventStreamProvider(CUSTOM_DRAG_ENTER);
+      new EventStreamProvider(CUSTOM_DRAG_ENTER);
 
   /// Stream provider for [CUSTOM_DRAG_OVER] events. The relatedTarget is empty.
   static EventStreamProvider<MouseEvent> overEvent =
-       new EventStreamProvider(CUSTOM_DRAG_OVER);
+      new EventStreamProvider(CUSTOM_DRAG_OVER);
 
   /// Stream provider for [CUSTOM_DRAG_LEAVE] events. The relatedTarget contains
   /// the [Element] the user is leaving to (may be null).
   static EventStreamProvider<MouseEvent> leaveEvent =
-       new EventStreamProvider(CUSTOM_DRAG_LEAVE);
+      new EventStreamProvider(CUSTOM_DRAG_LEAVE);
 
   /// Stream provider for [CUSTOM_DROP] events. The relatedTarget is empty.
   static EventStreamProvider<MouseEvent> dropEvent =
-       new EventStreamProvider(CUSTOM_DROP);
-
+      new EventStreamProvider(CUSTOM_DROP);
 
   /// Keeps track of the previous target to be able to fire dragLeave events on it.
   static EventTarget previousTarget;
@@ -45,7 +43,6 @@ class _DragEventDispatcher {
   /// The [draggable] is the [Draggable] that is dispatching the event.
   /// The [target] is the element that the event will be dispatched on.
   static void dispatchEnterOverLeave(Draggable draggable, EventTarget target) {
-
     // Sometimes the target is null (e.g. when user drags over buttons on
     // android). Ignore it.
     if (target == null) {
@@ -56,17 +53,16 @@ class _DragEventDispatcher {
       // Moved on the same element --> dispatch dragOver.
       MouseEvent dragOverEvent = new MouseEvent(CUSTOM_DRAG_OVER);
       target.dispatchEvent(dragOverEvent);
-
     } else {
       // Entered a new element --> fire dragEnter of new element.
-      MouseEvent dragEnterEvent = new MouseEvent(CUSTOM_DRAG_ENTER,
-          relatedTarget: previousTarget);
+      MouseEvent dragEnterEvent =
+          new MouseEvent(CUSTOM_DRAG_ENTER, relatedTarget: previousTarget);
       target.dispatchEvent(dragEnterEvent);
 
       // Fire dragLeave of old element (if there is one).
       if (previousTarget != null) {
-        MouseEvent dragLeaveEvent = new MouseEvent(CUSTOM_DRAG_LEAVE,
-            relatedTarget: target);
+        MouseEvent dragLeaveEvent =
+            new MouseEvent(CUSTOM_DRAG_LEAVE, relatedTarget: target);
         previousTarget.dispatchEvent(dragLeaveEvent);
       }
 
@@ -78,13 +74,11 @@ class _DragEventDispatcher {
     }
   }
 
-
   /// Dispatches drop event.
   ///
   /// The [draggable] is the [Draggable] that is dispatching the event.
   /// The [target] is the element that the event will be dispatched on.
   static void dispatchDrop(Draggable draggable, EventTarget target) {
-
     // Sometimes the target is null (e.g. when user drags over buttons on
     // android). Ignore it.
     if (target == null) {

--- a/lib/src/draggable_manager.dart
+++ b/lib/src/draggable_manager.dart
@@ -5,7 +5,6 @@ part of dnd;
 /// This class is an abstraction for the specific managers like
 /// [_TouchManager], [_MouseManager], etc.
 abstract class _EventManager {
-
   /// Attribute to mark custom elements where events should be retargeted
   /// to their Shadow DOM children.
   static const String SHADOW_DOM_RETARGET_ATTRIBUTE = 'dnd-retarget';
@@ -74,8 +73,8 @@ abstract class _EventManager {
     // Set the current position.
     _currentDrag.position = position;
 
-    if (!_currentDrag.started
-        && _currentDrag.startPosition != _currentDrag.position) {
+    if (!_currentDrag.started &&
+        _currentDrag.startPosition != _currentDrag.position) {
       // This is the first drag move.
 
       // Handle dragStart.
@@ -90,7 +89,8 @@ abstract class _EventManager {
   }
 
   /// Handles all end events (touchEnd, mouseUp, and pointerUp).
-  void handleEnd(Event event, EventTarget target, Point position, Point clientPosition) {
+  void handleEnd(
+      Event event, EventTarget target, Point position, Point clientPosition) {
     // Set the current position.
     _currentDrag.position = position;
 
@@ -125,7 +125,8 @@ abstract class _EventManager {
   ///
   /// Falls back to `document.body` if no element is found at the provided [clientPosition].
   EventTarget _getRealTargetFromPoint(Point clientPosition) {
-    return document.elementFromPoint(clientPosition.x, clientPosition.y) ?? document.body;
+    return document.elementFromPoint(clientPosition.x, clientPosition.y) ??
+        document.body;
   }
 
   /// Determine the actual target that should receive the event because
@@ -141,9 +142,9 @@ abstract class _EventManager {
     }
 
     // Test if target is the drag avatar.
-    if (drg.avatarHandler != null && drg.avatarHandler.avatar != null
-        && drg.avatarHandler.avatar.contains(target)) {
-
+    if (drg.avatarHandler != null &&
+        drg.avatarHandler.avatar != null &&
+        drg.avatarHandler.avatar.contains(target)) {
       // Target is the drag avatar, get element underneath.
       drg.avatarHandler.avatar.style.visibility = 'hidden';
       target = _getRealTargetFromPoint(clientPosition);
@@ -157,13 +158,14 @@ abstract class _EventManager {
 
   /// Recursively searches for the real target inside the Shadow DOM for all
   /// Shadow hosts with the attribute [SHADOW_DOM_RETARGET_ATTRIBUTE].
-  EventTarget _recursiveShadowDomTarget(Point clientPosition, EventTarget target) {
-
+  EventTarget _recursiveShadowDomTarget(
+      Point clientPosition, EventTarget target) {
     // Retarget if target is a shadow host and has the specific attribute.
-    if (target is Element && target.shadowRoot != null &&
+    if (target is Element &&
+        target.shadowRoot != null &&
         target.attributes.containsKey(SHADOW_DOM_RETARGET_ATTRIBUTE)) {
-
-      Element newTarget = (target as Element).shadowRoot
+      Element newTarget = (target as Element)
+          .shadowRoot
           .elementFromPoint(clientPosition.x, clientPosition.y);
 
       // Recursive call for nested shadow DOM trees.
@@ -178,10 +180,9 @@ abstract class _EventManager {
   /// provided, drag cannot be started on those elements.
   bool _isValidDragStartTarget(EventTarget target) {
     // Test if a drag was started on a cancel element.
-    if (drg.cancel != null
-        && target is Element
-        && target.matchesWithAncestors(drg.cancel)) {
-
+    if (drg.cancel != null &&
+        target is Element &&
+        target.matchesWithAncestors(drg.cancel)) {
       return false;
     }
 
@@ -217,13 +218,12 @@ abstract class _EventManager {
 
 /// Manages the browser's touch events.
 class _TouchManager extends _EventManager {
-
-  _TouchManager(Draggable draggable)
-      : super(draggable);
+  _TouchManager(Draggable draggable) : super(draggable);
 
   @override
   void installStart() {
-    startSubs.add(drg._elementOrElementList.onTouchStart.listen((TouchEvent event) {
+    startSubs
+        .add(drg._elementOrElementList.onTouchStart.listen((TouchEvent event) {
       // Ignore if drag is already beeing handled.
       if (_currentDrag != null) {
         return;
@@ -259,8 +259,8 @@ class _TouchManager extends _EventManager {
         return;
       }
 
-      handleMove(event, event.changedTouches[0].page,
-          event.changedTouches[0].client);
+      handleMove(
+          event, event.changedTouches[0].page, event.changedTouches[0].client);
 
       // Prevent touch scrolling.
       event.preventDefault();
@@ -270,7 +270,8 @@ class _TouchManager extends _EventManager {
   @override
   void installEnd() {
     dragSubs.add(document.onTouchEnd.listen((TouchEvent event) {
-      handleEnd(event, null, event.changedTouches[0].page, event.changedTouches[0].client);
+      handleEnd(event, null, event.changedTouches[0].page,
+          event.changedTouches[0].client);
     }));
   }
 
@@ -304,14 +305,12 @@ class _TouchManager extends _EventManager {
 
 /// Manages the browser's mouse events.
 class _MouseManager extends _EventManager {
-
-  _MouseManager(Draggable draggable)
-      : super(draggable);
-
+  _MouseManager(Draggable draggable) : super(draggable);
 
   @override
   void installStart() {
-    startSubs.add(drg._elementOrElementList.onMouseDown.listen((MouseEvent event) {
+    startSubs
+        .add(drg._elementOrElementList.onMouseDown.listen((MouseEvent event) {
       // Ignore if drag is already beeing handled.
       if (_currentDrag != null) {
         return;
@@ -336,9 +335,11 @@ class _MouseManager extends _EventManager {
       // * InputElement and TextAreaElement would not get focus.
       // * ButtonElement and OptionElement - don't know if this is needed??
       Element target = event.target;
-      if (!(target is SelectElement || target is InputElement ||
-            target is TextAreaElement || target is ButtonElement ||
-            target is OptionElement)) {
+      if (!(target is SelectElement ||
+          target is InputElement ||
+          target is TextAreaElement ||
+          target is ButtonElement ||
+          target is OptionElement)) {
         event.preventDefault();
       }
 
@@ -368,7 +369,6 @@ class _MouseManager extends _EventManager {
 
 /// Manages the browser's pointer events (used for Internet Explorer).
 class _PointerManager extends _EventManager {
-
   bool msPrefix;
 
   _PointerManager(Draggable draggable, {this.msPrefix: false})
@@ -393,11 +393,11 @@ class _PointerManager extends _EventManager {
 
     // Disable default touch actions on all elements (scrolling, panning, zooming).
     if (msPrefix) {
-      drg._elementOrElementList.style.setProperty('-ms-touch-action',
-          _getTouchActionValue());
+      drg._elementOrElementList.style
+          .setProperty('-ms-touch-action', _getTouchActionValue());
     } else {
-      drg._elementOrElementList.style.setProperty('touch-action',
-          _getTouchActionValue());
+      drg._elementOrElementList.style
+          .setProperty('touch-action', _getTouchActionValue());
     }
   }
 
@@ -424,6 +424,7 @@ class _PointerManager extends _EventManager {
     }));
   }
 
+  /// Listener in a separate method to be able to use the `covariant` keyword.
   void _listenForStartEvent(covariant MouseEvent event) {
     // Ignore if drag is already beeing handled.
     if (_currentDrag != null) {
@@ -449,19 +450,23 @@ class _PointerManager extends _EventManager {
     // * InputElement and TextAreaElement would not get focus.
     // * ButtonElement and OptionElement - don't know if this is needed??
     Element target = event.target;
-    if (!(target is SelectElement || target is InputElement ||
-          target is TextAreaElement || target is ButtonElement ||
-          target is OptionElement)) {
+    if (!(target is SelectElement ||
+        target is InputElement ||
+        target is TextAreaElement ||
+        target is ButtonElement ||
+        target is OptionElement)) {
       event.preventDefault();
     }
 
     handleStart(event, event.page);
   }
 
+  /// Listener in a separate method to be able to use the `covariant` keyword.
   void _listenForMoveEvent(covariant MouseEvent event) {
     handleMove(event, event.page, event.client);
   }
 
+  /// Listener in a separate method to be able to use the `covariant` keyword.
   void _listenForEndEvent(covariant MouseEvent event) {
     handleEnd(event, event.target, event.page, event.client);
   }

--- a/lib/src/dropzone.dart
+++ b/lib/src/dropzone.dart
@@ -13,7 +13,6 @@ part of dnd;
 ///
 /// A [Dropzone] can be created for one [Element] or an [ElementList].
 class Dropzone {
-
   // --------------
   // Options
   // --------------
@@ -40,8 +39,8 @@ class Dropzone {
   /// Fired when a [Draggable] enters this [Dropzone].
   Stream<DropzoneEvent> get onDragEnter {
     if (_onDragEnter == null) {
-      _onDragEnter = new StreamController<DropzoneEvent>.broadcast(sync: true,
-          onCancel: () => _onDragEnter = null);
+      _onDragEnter = new StreamController<DropzoneEvent>.broadcast(
+          sync: true, onCancel: () => _onDragEnter = null);
     }
     return _onDragEnter.stream;
   }
@@ -49,8 +48,8 @@ class Dropzone {
   /// Fired periodically while a [Draggable] is moved over a [Dropzone].
   Stream<DropzoneEvent> get onDragOver {
     if (_onDragOver == null) {
-      _onDragOver = new StreamController<DropzoneEvent>.broadcast(sync: true,
-          onCancel: () => _onDragOver = null);
+      _onDragOver = new StreamController<DropzoneEvent>.broadcast(
+          sync: true, onCancel: () => _onDragOver = null);
     }
     return _onDragOver.stream;
   }
@@ -58,8 +57,8 @@ class Dropzone {
   /// Fired when a [Draggable] leaves this [Dropzone].
   Stream<DropzoneEvent> get onDragLeave {
     if (_onDragLeave == null) {
-      _onDragLeave = new StreamController<DropzoneEvent>.broadcast(sync: true,
-          onCancel: () => _onDragLeave = null);
+      _onDragLeave = new StreamController<DropzoneEvent>.broadcast(
+          sync: true, onCancel: () => _onDragLeave = null);
     }
     return _onDragLeave.stream;
   }
@@ -68,8 +67,8 @@ class Dropzone {
   /// inside this [Dropzone].
   Stream<DropzoneEvent> get onDrop {
     if (_onDrop == null) {
-      _onDrop = new StreamController<DropzoneEvent>.broadcast(sync: true,
-          onCancel: () => _onDrop = null);
+      _onDrop = new StreamController<DropzoneEvent>.broadcast(
+          sync: true, onCancel: () => _onDrop = null);
     }
     return _onDrop.stream;
   }
@@ -104,11 +103,10 @@ class Dropzone {
   /// not-accepted [Draggable] is dragged over it. If set to null, no such css
   /// class is added.
   Dropzone(elementOrElementList,
-      { this.acceptor: null,
-        this.overClass: 'dnd-over',
-        this.invalidClass: 'dnd-invalid'})
+      {this.acceptor: null,
+      this.overClass: 'dnd-over',
+      this.invalidClass: 'dnd-invalid'})
       : this._elementOrElementList = elementOrElementList {
-
     // Install drag listener on Element or ElementList.
     if (_elementOrElementList is ElementList) {
       _elementOrElementList.forEach(_installCustomDragListener);
@@ -120,22 +118,25 @@ class Dropzone {
   /// Installs the custom drag listeners (dragEnter, dragOver, dragLeave, and
   /// drop) on [element].
   void _installCustomDragListener(Element element) {
-    _subs.add(_DragEventDispatcher.enterEvent.forTarget(element)
+    _subs.add(_DragEventDispatcher.enterEvent
+        .forTarget(element)
         .listen(_handleDragEnter));
-    _subs.add(_DragEventDispatcher.overEvent.forTarget(element)
+    _subs.add(_DragEventDispatcher.overEvent
+        .forTarget(element)
         .listen(_handleDragOver));
-    _subs.add(_DragEventDispatcher.leaveEvent.forTarget(element)
+    _subs.add(_DragEventDispatcher.leaveEvent
+        .forTarget(element)
         .listen(_handleDragLeave));
-    _subs.add(_DragEventDispatcher.dropEvent.forTarget(element)
-        .listen(_handleDrop));
+    _subs.add(
+        _DragEventDispatcher.dropEvent.forTarget(element).listen(_handleDrop));
   }
 
   /// Handles dragEnter events.
   void _handleDragEnter(MouseEvent event) {
     // Only handle dragEnter if user moved from outside of element into the
     // element. That means we ignore it if user is coming from a child element.
-    if (event.relatedTarget != null
-        && (event.currentTarget as Element).contains(event.relatedTarget)) {
+    if (event.relatedTarget != null &&
+        (event.currentTarget as Element).contains(event.relatedTarget)) {
       return;
     }
 
@@ -144,10 +145,10 @@ class Dropzone {
     if (acceptor == null ||
         acceptor.accepts(_currentDrag.element, _currentDrag.draggableId,
             event.currentTarget)) {
-
       // Fire dragEnter event.
       if (_onDragEnter != null) {
-        _onDragEnter.add(new DropzoneEvent._(event.currentTarget, _currentDrag));
+        _onDragEnter
+            .add(new DropzoneEvent._(event.currentTarget, _currentDrag));
       }
 
       // Add the css class to indicate drag over.
@@ -155,7 +156,6 @@ class Dropzone {
         (event.currentTarget as Element).classes.add(overClass);
       }
     } else {
-
       // Add the css class to indicate invalid drag over.
       if (invalidClass != null) {
         (event.currentTarget as Element).classes.add(invalidClass);
@@ -168,8 +168,8 @@ class Dropzone {
     // Test if the current draggable is accepted by this dropzone. If there is
     // no accepter all are accepted.
     if (acceptor == null ||
-        acceptor.accepts(_currentDrag.element, _currentDrag.draggableId, event.currentTarget)) {
-
+        acceptor.accepts(_currentDrag.element, _currentDrag.draggableId,
+            event.currentTarget)) {
       // Fire dragOver event.
       if (_onDragOver != null) {
         _onDragOver.add(new DropzoneEvent._(event.currentTarget, _currentDrag));
@@ -181,8 +181,8 @@ class Dropzone {
   void _handleDragLeave(MouseEvent event) {
     // Only handle dragLeave if user moved from inside of element to the
     // outside. That means we ignore it if user is moving to a child element.
-    if (event.relatedTarget != null
-        && (event.currentTarget as Element).contains(event.relatedTarget)) {
+    if (event.relatedTarget != null &&
+        (event.currentTarget as Element).contains(event.relatedTarget)) {
       return;
     }
 
@@ -191,10 +191,10 @@ class Dropzone {
     if (acceptor == null ||
         acceptor.accepts(_currentDrag.element, _currentDrag.draggableId,
             event.currentTarget)) {
-
       // Fire dragLeave event.
       if (_onDragLeave != null) {
-        _onDragLeave.add(new DropzoneEvent._(event.currentTarget, _currentDrag));
+        _onDragLeave
+            .add(new DropzoneEvent._(event.currentTarget, _currentDrag));
       }
 
       // Remove the css class.
@@ -202,14 +202,12 @@ class Dropzone {
         (event.currentTarget as Element).classes.remove(overClass);
       }
     } else {
-
       // Remove the invalid drag css class.
       if (invalidClass != null) {
         (event.currentTarget as Element).classes.remove(invalidClass);
       }
     }
   }
-
 
   /// Handles drop events.
   void _handleDrop(MouseEvent event) {
@@ -218,7 +216,6 @@ class Dropzone {
     if (acceptor == null ||
         acceptor.accepts(_currentDrag.element, _currentDrag.draggableId,
             event.currentTarget)) {
-
       // Fire drop event.
       if (_onDrop != null) {
         _onDrop.add(new DropzoneEvent._(event.currentTarget, _currentDrag));
@@ -232,7 +229,6 @@ class Dropzone {
     _subs.clear();
   }
 }
-
 
 /// Event for dropzone elements.
 class DropzoneEvent {

--- a/lib/src/dropzone_acceptor.dart
+++ b/lib/src/dropzone_acceptor.dart
@@ -2,7 +2,6 @@ part of dnd;
 
 /// An acceptor defines which draggable elements are accepted by a [Dropzone].
 abstract class Acceptor {
-
   Acceptor();
 
   /// Creates an [Acceptor] that accepts all drag elements that are part of the
@@ -15,13 +14,13 @@ abstract class Acceptor {
 
   /// Returns true if the [draggableElement] with [draggableId] should be
   /// accepted by the [dropzoneElement].
-  bool accepts(Element draggableElement, int draggableId, Element dropzoneElement);
+  bool accepts(
+      Element draggableElement, int draggableId, Element dropzoneElement);
 }
 
 /// The [DraggablesAcceptor] accepts all drag elements that are part of the
 /// specified list of [Draggable]s.
 class DraggablesAcceptor extends Acceptor {
-
   final Set<int> draggableIds = new Set();
 
   DraggablesAcceptor(List<Draggable> draggables) {
@@ -29,7 +28,8 @@ class DraggablesAcceptor extends Acceptor {
   }
 
   @override
-  bool accepts(Element draggableElement, int draggableId, Element dropzoneElement) {
+  bool accepts(
+      Element draggableElement, int draggableId, Element dropzoneElement) {
     return draggableIds.contains(draggableId);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dnd
-version: 0.3.6
+version: 0.4.0
 author: Marco Jakob <majakob@gmx.ch>
 description: Drag and Drop for Dart web apps with mouse and touch support.
 homepage: http://code.makery.ch/library/dart-drag-and-drop/
-documentation: http://www.dartdocs.org/documentation/dnd/latest/
+documentation: https://www.dartdocs.org/documentation/dnd/latest/
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:


### PR DESCRIPTION
These changes fix strong-mode errors seen when using the Dart Dev Compiler (and in the analyzer, when run with Dart SDK 1.24.1):

```
error: The argument type '(MouseEvent) → Null' can't be assigned to the parameter type '(Event) → void'
```

I also turned on a few memory-leak-related analyzer lints.

@marcojakob 