### PR TITLE
Add null checks to avoid #35

### DIFF
--- a/lib/src/draggable_manager.dart
+++ b/lib/src/draggable_manager.dart
@@ -104,7 +104,7 @@ abstract class _EventManager {
   void handleEnd(Event event, EventTarget? target, Point? position,
       Point? clientPosition) {
     // Set the current position.
-    if (position != null) {
+    if (position != null && _currentDrag != null) {
       _currentDrag!.position = position;
     }
 


### PR DESCRIPTION
In production, we're seeing a lot of unhandled JS errors reported to New Relic, even on version 2.0.0. When tracking down the line numbers from the problem it looks like this location could stand to benefit from a null check to avoid the runtime error.
I think what is happening is that `_currentDrag` is null and the `!` on it is the problem.

![image](https://user-images.githubusercontent.com/6053699/136309657-5e146918-c873-4e54-b44d-ea3f03a510c9.png)
![image](https://user-images.githubusercontent.com/6053699/136309692-96605ca9-eac9-4b1a-98c1-551320e86dfe.png)

This would hopefully fix #35. Ping @marcojakob 